### PR TITLE
Document the recipe that needs to be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ use an `s3://...` uri, then the `remote_or_s3_file` will act like the
 
 ## Usage
 
+Include the default recipe to ensure the aws-sdk is installed in Chef
+
+```ruby
+include_recipe 'remote_or_s3_file'
+```
+
+Then to download to a file from a non-S3 bucket
+
 ```ruby
 remote_or_s3_file 'example.zip' do
   source 'http://example.com/example.zip'


### PR DESCRIPTION
It needs to be included to ensure the aws-sdk gem is installed.
